### PR TITLE
Improved performance of the UTF-8 check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: php
-php:
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
+dist: trusty
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: hhvm
 before_script:
   - composer install --dev
 script:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "squizlabs/php_codesniffer": "~2.2",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "~1.0"
+    },
+    "suggest": {
+        "ext-mbstring": "May increase performance encoding characters"
     },
     "autoload": {
         "psr-4": {"Minphp\\Html\\": "src"}

--- a/src/Html.php
+++ b/src/Html.php
@@ -59,42 +59,17 @@ class Html
      */
     public function isUtf8($str)
     {
-        $c = 0;
-        $b = 0;
-        $bits = 0;
-        $len = strlen($str);
-        for ($i=0; $i<$len; $i++) {
-            $c = ord($str[$i]);
-            if ($c > 128) {
-                if (($c >= 254)) {
-                    return false;
-                } elseif ($c >= 252) {
-                    $bits=6;
-                } elseif ($c >= 248) {
-                    $bits=5;
-                } elseif ($c >= 240) {
-                    $bits=4;
-                } elseif ($c >= 224) {
-                    $bits=3;
-                } elseif ($c >= 192) {
-                    $bits=2;
-                } else {
-                    return false;
-                }
-                if (($i+$bits) > $len) {
-                    return false;
-                }
-                while ($bits > 1) {
-                    $i++;
-                    $b = ord($str[$i]);
-                    if ($b < 128 || $b > 191) {
-                        return false;
-                    }
-                    $bits--;
-                }
-            }
+        if ($str === null || $str === '') {
+            return true;
         }
-        return true;
+
+        // Detect the multi-byte encoding if possible
+        if (function_exists('mb_detect_encoding')) {
+            return ('UTF-8' === mb_detect_encoding($str, 'UTF-8', true));
+        }
+
+        // Check that the string is valid UTF-8 via regex
+        return (bool)preg_match('/\S/u', $str);
     }
 
     /**

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -11,6 +11,56 @@ class HtmlTest extends PHPUnit_Framework_TestCase
 {
     public function testConstruct()
     {
-        $this->assertInstanceOf('\Minphp\Html\Html', new Html());
+        $this->assertInstanceOf('\Minphp\Html\Html', $this->getHtml());
+    }
+
+    /**
+     * @covers ::isUtf8
+     * @dataProvider isUtf8DataProvider
+     */
+    public function testIsUtf8($string, $result)
+    {
+        $html = $this->getHtml();
+
+        $this->assertEquals($result, $html->isUtf8($string));
+    }
+
+    /**
+     * Data Provider for ::testIsUtf8
+     */
+    public function isUtf8DataProvider()
+    {
+        return array(
+            array('', true),
+            array('abc', true),
+            array('123', true),
+            array('test string here', true),
+            array(123, true),
+            array(null, true),
+            array('\xe2\x80\x80', true),
+            array('áéóú', true),
+            array(chr(0x00), true),
+            array('�', true),
+            array(pack('l', 1), true),
+            array(pack('l', -1), false), // byte 1 starts 1xxxx.. instead of 0xxxx..
+            array(utf8_encode(pack('l', -1)), true), // byte 1 starts 1xxxx.. instead of 0xxxx, but UTF-8 encoding works
+            array(pack('L', 123456), false),
+            array(pack('LLLL', 0, 1, 2, 3), true),
+            array(pack('LLLL', 0, -1, 2, 3), false), // byte 1 is valid, but byte 2 starts 11xxxx.. instead of 10xxxx...
+            array(pack('LLLL', 0, 1, -2, 3), false), // byte 1 and 2 are valid, byte 3 is not
+            array(pack('LLLL', 0, 1, 2, -3), false), // bytes 1-3 are valid, byte 4 is not
+            array(pack('LLLLLL', 1, 1, 1, 1, 1, 1), true), // 6 valid bytes
+            array(pack('LLLLLL', 1, 1, 1, 1, -1, 1), false), // bytes 1-4 are valid, byte 5 is not
+            array(pack('LLLLLL', 1, 1, 1, 1, 1, -1), false), // bytes 1-5 are valid, byte 6 is not
+            array(utf8_encode(pack('LLLLLL', 1, 1, 1, 1, 1, -1)), true), // UTF-8 encoded invalid byte sequence is valid
+        );
+    }
+
+    /**
+     * @return Html
+     */
+    private function getHtml()
+    {
+        return new Html();
     }
 }


### PR DESCRIPTION
Fixes #2
Replaced the old algorithm with a simple regex check for UTF-8. Also added mb_detect_encoding if the ext-mbstring extension is enabled.
For small strings, mb_detect_encoding performs about the same as the regex.
For large strings, it appears that the regex is noticably quicker (e.g. 1.5x to 4x faster for a 10,000 byte sequence).
Compared to the old algorithm, both mb_detect_encoding and the regex are about 30x to 40x quicker.